### PR TITLE
Create midreview_mack_micah

### DIFF
--- a/Arduino/IntroProjects/midreview_mack_micah
+++ b/Arduino/IntroProjects/midreview_mack_micah
@@ -1,0 +1,103 @@
+// as of 9/22/2025, this code works for Mack. 
+
+
+#include <FastLED.h>
+
+#define LED_PIN        6       // Data pin for LED strip
+#define NUM_LEDS       8       // Only 8 LEDs now
+#define MASTER_PIN     3       // Master ON/OFF button (to GND)
+#define TRIGGER_PIN    2       // Trigger orb button (to GND)
+#define HUE_POT        A1
+#define INTENSITY_POT  A2
+#define VOLUME_POT     A3      // layup for Micah
+
+CRGB leds[NUM_LEDS];
+
+bool masterOn = false;
+bool running  = false;
+int orbPos = 0;
+unsigned long lastUpdate = 0;
+
+// Orb config
+const int tailLength = 4;       // currently short because of the 8 leds, will need to be adjusted for much more LEDS
+const int orbDelay   = 1250;    // ~10 sec total for 8 LEDs, to change do seconds/num leds for orb progression
+const int glowLength = 1;
+
+bool lastTriggerState = HIGH;
+bool lastMasterState  = HIGH;
+
+void setup() {
+  FastLED.addLeds<WS2812B, LED_PIN, GRB>(leds, NUM_LEDS);
+  FastLED.clear();
+  FastLED.show();
+
+  pinMode(TRIGGER_PIN, INPUT_PULLUP);
+  pinMode(MASTER_PIN, INPUT_PULLUP);
+  pinMode(LED_BUILTIN, OUTPUT);
+
+  digitalWrite(LED_BUILTIN, LOW); // Start OFF
+}
+
+void loop() {
+  // ----- MASTER BUTTON -----
+  bool masterState = digitalRead(MASTER_PIN);
+  if (lastMasterState == HIGH && masterState == LOW) {
+    masterOn = !masterOn;  // toggle state
+    digitalWrite(LED_BUILTIN, masterOn ? HIGH : LOW);
+
+    if (!masterOn) {
+      running = false;
+      FastLED.clear();
+      FastLED.show();
+    }
+  }
+  lastMasterState = masterState;
+
+  if (!masterOn) return; // skip everything if master is OFF
+
+  // ----- TRIGGER BUTTON -----
+  bool triggerState = digitalRead(TRIGGER_PIN);
+  if (lastTriggerState == HIGH && triggerState == LOW) {
+    running = true;
+    orbPos = 0;
+  }
+  lastTriggerState = triggerState;
+
+  // ----- ORB ANIMATION -----
+  if (running && millis() - lastUpdate >= orbDelay) {
+    lastUpdate = millis();
+
+    // Limit hue range so it doesn’t wrap back to red
+    int baseHue = map(analogRead(HUE_POT), 0, 1023, 0, 192); // red → blue // doesn't go up to 255 for no repeat hues
+    float intensityScale = analogRead(INTENSITY_POT) / 1023.0;
+
+    FastLED.clear();
+
+    // Tail
+    for (int i = 0; i < tailLength; i++) {
+      int pos = orbPos - i;
+      if (pos >= 0 && pos < NUM_LEDS) {
+        uint8_t brightness = (uint8_t)(255 * (1.0 - (float)i / tailLength) * intensityScale);
+        leds[pos] = CHSV(baseHue, 255, brightness);
+      }
+    }
+
+    // Glow ahead
+    for (int g = 1; g <= glowLength; g++) {
+      int pos = orbPos + g;
+      if (pos < NUM_LEDS) {
+        uint8_t glowBrightness = (uint8_t)(150 * intensityScale * (1.0 - (float)(g - 1) / glowLength));
+        leds[pos] = CHSV(baseHue, 255, glowBrightness);
+      }
+    }
+
+    FastLED.show();
+
+    orbPos++;
+    if (orbPos - tailLength >= NUM_LEDS) {
+      running = false;
+      FastLED.clear();
+      FastLED.show();
+    }
+  }
+}


### PR DESCRIPTION
Mack's first submission of the mid-review code. This was tested at home with the 8 GLOW LED strip. There are two basic buttons, one being the master on/off button, and the other being what detects the signal. This will be replaced with the sinulator when the time comes. The two pots, one is for hue and the other is for intensity. 

Before any major testing with more LEDs, there are a few items that need to be tweaked in the code, beginning with the NUM_LEDS. 

There is room, and hopefully it is clear enough to Micah what I did for him to add his sound code. I have added his input to the define function.