### PR TITLE
Changes to UserControl from LL review

### DIFF
--- a/UserControls/UserControls.ino
+++ b/UserControls/UserControls.ino
@@ -183,7 +183,7 @@ void loop() {
         digitalWrite(SPOTLIGHTPIN, LOW); // Spotlight turns ON
       }
 
-      setAllColor(255, 255, 255, 255); // solid white
+      setAllColor(155, 0, 255, 255); // solid white
 
       // LL thinks this isn't doing what you think it is. It's changing the hue by 256 every ORB_DELAY. (50 ms). I think this is the crazy christmas lights effect you were seeing. 
       // if (now - lastPulseTime >= ORB_DELAY) {


### PR DESCRIPTION
Made a bunch of changes to UserControl @mackenziehenley 

* Adding phases and fixing one phase bug.
* Removing the opacity film control from here -- we want that to be controlled by the coincidence receiver. @headunderheels 
* Renamed confusing pin names
* Adding configurable spotlight delay and synchronizing phases with latest script skeleton
* Fixing some indentation.
* Unifying presence-based reset to a single check at the end of the loop -- no need to repeat in every case of the switch.
* Removing buggy rainbow
* New LED fade out on the last phase

To be tested. If this works as expected, let's merge this into `dev/usercontrol` and to `main`.